### PR TITLE
pin skimage to <0.19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requirements = [
     "aicsimageio>=4.0.5",
     "scipy>=1.1.0",
     "numpy>=1.15.1",
-    "scikit-image>=0.18.0",
+    "scikit-image>=0.18.0,<0.19.0",
     "pandas>=0.23.4",
     "itk",
     "itkwidgets",


### PR DESCRIPTION
A skimage update prevented unit tests from passing, pinning skimage version to <0.19.0 keeps the test behavior the same. 



**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
