### PR TITLE
allow scikit-image==0.19.2

### DIFF
--- a/aicssegmentation/bin/batch_processing.py
+++ b/aicssegmentation/bin/batch_processing.py
@@ -169,7 +169,7 @@ class Args(object):
         log.debug("Command Line:")
         log.debug("\t{}".format(" ".join(sys.argv)))
         log.debug("Args:")
-        for (k, v) in self.__dict__.items():
+        for k, v in self.__dict__.items():
             log.debug("\t{}: {}".format(k, v))
 
 
@@ -178,7 +178,6 @@ class Args(object):
 
 class Executor(object):
     def __init__(self, args):
-
         standard_xy = 0.108
 
         if args.rescale > 0:
@@ -274,7 +273,6 @@ class Executor(object):
         ##########################################################################
         batch_mode = False
         if args.mode == PER_IMAGE:
-
             fname = os.path.basename(os.path.splitext(args.input_fname)[0])
 
             image_reader = aicsimageio.AICSImage(args.input_fname)

--- a/aicssegmentation/core/MO_threshold.py
+++ b/aicssegmentation/core/MO_threshold.py
@@ -51,7 +51,7 @@ def MO_low_level(
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=object_minArea, connectivity=1, in_place=True)
     if dilate:
-        bw_low_level = dilation(bw_low_level, selem=ball(2))
+        bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     return bw_low_level
 

--- a/aicssegmentation/core/MO_threshold.py
+++ b/aicssegmentation/core/MO_threshold.py
@@ -49,7 +49,7 @@ def MO_low_level(
         th_low_level = (global_tri + global_median) / 2
 
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=object_minArea, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=object_minArea, connectivity=1, out=bw_low_level)
     if dilate:
         bw_low_level = dilation(bw_low_level, footprint=ball(2))
 

--- a/aicssegmentation/core/hessian.py
+++ b/aicssegmentation/core/hessian.py
@@ -48,9 +48,9 @@ def compute_3d_hessian_matrix(
     if sigma > 0 and scale:
         # scale the elements of the hessian matrix
         if whiteonblack:
-            hessian_elements = [(sigma ** 2) * element for element in hessian_elements]
+            hessian_elements = [(sigma**2) * element for element in hessian_elements]
         else:
-            hessian_elements = [-1 * (sigma ** 2) * element for element in hessian_elements]
+            hessian_elements = [-1 * (sigma**2) * element for element in hessian_elements]
 
     # create hessian matrix from hessian elements
     hessian_full = [[()] * ndim for x in range(ndim)]

--- a/aicssegmentation/core/output_utils.py
+++ b/aicssegmentation/core/output_utils.py
@@ -40,7 +40,7 @@ def save_segmentation(
 def generate_segmentation_contour(im):
     """generate the contour of the segmentation"""
 
-    bd = np.logical_xor(erosion(im > 0, selem=ball(1)), im > 0)
+    bd = np.logical_xor(erosion(im > 0, footprint=ball(1)), im > 0)
 
     bd = bd.astype(np.uint8)
     bd[bd > 0] = 255

--- a/aicssegmentation/core/seg_dot.py
+++ b/aicssegmentation/core/seg_dot.py
@@ -20,7 +20,7 @@ def dot_3d(struct_img: np.ndarray, log_sigma: float, cutoff=-1):
         negative, no cutoff will be applied. Default is -1
     """
     assert len(struct_img.shape) == 3
-    responce = -1 * (log_sigma ** 2) * gaussian_laplace(struct_img, log_sigma)
+    responce = -1 * (log_sigma**2) * gaussian_laplace(struct_img, log_sigma)
     if cutoff < 0:
         return responce
     else:
@@ -44,7 +44,7 @@ def dot_2d(struct_img, log_sigma, cutoff=-1):
         negative, no cutoff will be applied. Default is -1
     """
     assert len(struct_img.shape) == 2
-    responce = -1 * (log_sigma ** 2) * gaussian_laplace(struct_img, log_sigma)
+    responce = -1 * (log_sigma**2) * gaussian_laplace(struct_img, log_sigma)
     if cutoff < 0:
         return responce
     else:
@@ -73,7 +73,7 @@ def dot_3d_wrapper(struct_img: np.ndarray, s3_param: List):
     bw = np.zeros(struct_img.shape, dtype=bool)
     for fid in range(len(s3_param)):
         log_sigma = s3_param[fid][0]
-        responce = -1 * (log_sigma ** 2) * gaussian_laplace(struct_img, log_sigma)
+        responce = -1 * (log_sigma**2) * gaussian_laplace(struct_img, log_sigma)
         bw = np.logical_or(bw, responce > s3_param[fid][1])
     return bw
 
@@ -91,7 +91,7 @@ def logSlice(image: np.ndarray, sigma_list: List, threshold: float):
         the cutoff to apply to get the binary output
     """
 
-    gl_images = [-gaussian_laplace(image, s) * (s ** 2) for s in sigma_list]
+    gl_images = [-gaussian_laplace(image, s) * (s**2) for s in sigma_list]
 
     # get the mask
     seg = np.zeros_like(image)
@@ -119,7 +119,7 @@ def dot_slice_by_slice(struct_img: np.ndarray, log_sigma: float, cutoff=-1):
     """
     res = np.zeros_like(struct_img)
     for zz in range(struct_img.shape[0]):
-        res[zz, :, :] = -1 * (log_sigma ** 2) * gaussian_laplace(struct_img[zz, :, :], log_sigma)
+        res[zz, :, :] = -1 * (log_sigma**2) * gaussian_laplace(struct_img[zz, :, :], log_sigma)
 
     if cutoff < 0:
         return res
@@ -151,6 +151,6 @@ def dot_2d_slice_by_slice_wrapper(struct_img: np.ndarray, s2_param: List):
         log_sigma = s2_param[fid][0]
         responce = np.zeros_like(struct_img)
         for zz in range(struct_img.shape[0]):
-            responce[zz, :, :] = -1 * (log_sigma ** 2) * gaussian_laplace(struct_img[zz, :, :], log_sigma)
+            responce[zz, :, :] = -1 * (log_sigma**2) * gaussian_laplace(struct_img[zz, :, :], log_sigma)
         bw = np.logical_or(bw, responce > s2_param[fid][1])
     return bw

--- a/aicssegmentation/core/utils.py
+++ b/aicssegmentation/core/utils.py
@@ -84,7 +84,7 @@ def size_filter(img: np.ndarray, min_size: int, method: str = "3D", connectivity
     """
     assert len(img.shape) == 3, "image has to be 3D"
     if method == "3D":
-        return remove_small_objects(img > 0, min_size=min_size, connectivity=connectivity, in_place=False)
+        return remove_small_objects(img > 0, min_size=min_size, connectivity=connectivity)
     elif method == "slice_by_slice":
         seg = np.zeros(img.shape, dtype=bool)
         for zz in range(img.shape[0]):
@@ -92,7 +92,6 @@ def size_filter(img: np.ndarray, min_size: int, method: str = "3D", connectivity
                 img[zz, :, :] > 0,
                 min_size=min_size,
                 connectivity=connectivity,
-                in_place=False,
             )
         return seg
     else:
@@ -423,7 +422,7 @@ def segmentation_xor(seg: List) -> np.ndarray:
     return np.logical_xor.reduce(seg)
 
 
-def remove_index_object(label: np.ndarray, id_to_remove: List[int] = [1], in_place=False):
+def remove_index_object(label: np.ndarray, id_to_remove: List[int] = [1]):
     if in_place:
         img = label
     else:
@@ -507,7 +506,7 @@ def cell_local_adaptive_threshold(structure_img_smooth: np.ndarray, cell_wise_mi
     th_low_level = threshold_triangle(structure_img_smooth)
 
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1, out=bw_low_level)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     bw_high_level = np.zeros_like(bw_low_level)

--- a/aicssegmentation/core/utils.py
+++ b/aicssegmentation/core/utils.py
@@ -422,7 +422,7 @@ def segmentation_xor(seg: List) -> np.ndarray:
     return np.logical_xor.reduce(seg)
 
 
-def remove_index_object(label: np.ndarray, id_to_remove: List[int] = [1]):
+def remove_index_object(label: np.ndarray, id_to_remove: List[int] = [1], in_place: bool = False) -> np.ndarray:
     if in_place:
         img = label
     else:

--- a/aicssegmentation/core/utils.py
+++ b/aicssegmentation/core/utils.py
@@ -454,7 +454,7 @@ def watershed_wrapper(bw: np.ndarray, local_maxi: np.ndarray) -> np.ndarray:
     distance = distance_transform_edt(bw)
     im_watershed = watershed(
         -distance,
-        label(dilation(local_maxi, selem=ball(1))),
+        label(dilation(local_maxi, footprint=ball(1))),
         mask=bw,
         watershed_line=True,
     )
@@ -509,7 +509,7 @@ def cell_local_adaptive_threshold(structure_img_smooth: np.ndarray, cell_wise_mi
 
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     bw_high_level = np.zeros_like(bw_low_level)
     lab_low, num_obj = label(bw_low_level, return_num=True, connectivity=1)

--- a/aicssegmentation/core/utils.py
+++ b/aicssegmentation/core/utils.py
@@ -424,7 +424,6 @@ def segmentation_xor(seg: List) -> np.ndarray:
 
 
 def remove_index_object(label: np.ndarray, id_to_remove: List[int] = [1], in_place=False):
-
     if in_place:
         img = label
     else:

--- a/aicssegmentation/structure_wrapper/seg_actb.py
+++ b/aicssegmentation/structure_wrapper/seg_actb.py
@@ -93,7 +93,7 @@ def Workflow_actb(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_actn1.py
+++ b/aicssegmentation/structure_wrapper/seg_actn1.py
@@ -124,7 +124,7 @@ def Workflow_actn1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_atp2a2.py
+++ b/aicssegmentation/structure_wrapper/seg_atp2a2.py
@@ -89,11 +89,11 @@ def Workflow_atp2a2(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_actn2.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_actn2.py
@@ -89,7 +89,7 @@ def Workflow_cardio_actn2(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_atp2a2.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_atp2a2.py
@@ -89,7 +89,7 @@ def Workflow_cardio_atp2a2(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_fbl.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_fbl.py
@@ -99,7 +99,7 @@ def Workflow_cardio_fbl(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)
@@ -117,7 +117,7 @@ def Workflow_cardio_fbl(
     # step 3: finer segmentation
     response2d = dot_slice_by_slice(structure_img_smooth, log_sigma=dot_2d_sigma)
 
-    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw_finer.copy())
     out_name_list.append("bw_fine")
@@ -129,7 +129,7 @@ def Workflow_cardio_fbl(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_fbl_100x.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_fbl_100x.py
@@ -99,7 +99,7 @@ def Workflow_cardio_fbl_100x(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)
@@ -117,7 +117,7 @@ def Workflow_cardio_fbl_100x(
     # step 3: finer segmentation
     response2d = dot_slice_by_slice(structure_img_smooth, log_sigma=dot_2d_sigma)
 
-    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw_finer.copy())
     out_name_list.append("bw_fine")
@@ -129,7 +129,7 @@ def Workflow_cardio_fbl_100x(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_myl7.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_myl7.py
@@ -89,7 +89,7 @@ def Workflow_cardio_myl7(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_npm1.py
@@ -106,7 +106,7 @@ def Workflow_cardio_npm1(
     # imsave('img_smooth.tiff', structure_img_smooth)
 
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
@@ -135,7 +135,7 @@ def Workflow_cardio_npm1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_npm1.py
@@ -107,7 +107,7 @@ def Workflow_cardio_npm1(
 
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)

--- a/aicssegmentation/structure_wrapper/seg_cardio_npm1_100x.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_npm1_100x.py
@@ -106,7 +106,7 @@ def Workflow_cardio_npm1_100x(
     # imsave('img_smooth.tiff', structure_img_smooth)
 
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
@@ -135,7 +135,7 @@ def Workflow_cardio_npm1_100x(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_npm1_100x.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_npm1_100x.py
@@ -107,7 +107,7 @@ def Workflow_cardio_npm1_100x(
 
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)

--- a/aicssegmentation/structure_wrapper/seg_cardio_tnni1.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_tnni1.py
@@ -89,7 +89,7 @@ def Workflow_cardio_tnni1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cardio_ttn.py
+++ b/aicssegmentation/structure_wrapper/seg_cardio_ttn.py
@@ -89,7 +89,7 @@ def Workflow_cardio_ttn(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_cetn2.py
+++ b/aicssegmentation/structure_wrapper/seg_cetn2.py
@@ -121,7 +121,7 @@ def Workflow_cetn2(
     distance = distance_transform_edt(bw)
     im_watershed = watershed(
         -distance,
-        label(dilation(local_maxi, selem=ball(1))),
+        label(dilation(local_maxi, footprint=ball(1))),
         mask=bw,
         watershed_line=True,
     )

--- a/aicssegmentation/structure_wrapper/seg_cetn2.py
+++ b/aicssegmentation/structure_wrapper/seg_cetn2.py
@@ -107,7 +107,7 @@ def Workflow_cetn2(
     # step 1: LOG 3d
     response = dot_3d(structure_img_smooth_for_seg, log_sigma=dot_3d_sigma)
     bw = response > dot_3d_cutoff
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw.copy())
     out_name_list.append("interm_mask")
@@ -129,7 +129,7 @@ def Workflow_cetn2(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_ctnnb1.py
+++ b/aicssegmentation/structure_wrapper/seg_ctnnb1.py
@@ -95,7 +95,7 @@ def Workflow_ctnnb1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_drug_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_drug_npm1.py
@@ -99,7 +99,7 @@ def Workflow_drug_npm1(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     bw_high_level = np.zeros_like(bw_low_level)
@@ -125,7 +125,7 @@ def Workflow_drug_npm1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_dsp.py
+++ b/aicssegmentation/structure_wrapper/seg_dsp.py
@@ -98,7 +98,7 @@ def Workflow_dsp(
     # step 1: LOG 3d
     response = dot_3d(structure_img_smooth, log_sigma=dot_3d_sigma)
     bw = response > dot_3d_cutoff
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw.copy())
     out_name_list.append("interm_mask")
@@ -120,7 +120,7 @@ def Workflow_dsp(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_dsp.py
+++ b/aicssegmentation/structure_wrapper/seg_dsp.py
@@ -112,7 +112,7 @@ def Workflow_dsp(
     distance = distance_transform_edt(bw)
     im_watershed = watershed(
         -distance,
-        label(dilation(local_maxi, selem=ball(1))),
+        label(dilation(local_maxi, footprint=ball(1))),
         mask=bw,
         watershed_line=True,
     )

--- a/aicssegmentation/structure_wrapper/seg_fbl.py
+++ b/aicssegmentation/structure_wrapper/seg_fbl.py
@@ -99,7 +99,7 @@ def Workflow_fbl(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     bw_high_level = np.zeros_like(bw_low_level)
@@ -114,7 +114,7 @@ def Workflow_fbl(
 
     # step 3: finer segmentation
     response2d = dot_slice_by_slice(structure_img_smooth, log_sigma=dot_2d_sigma)
-    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw_finer.copy())
     out_name_list.append("bw_fine")
@@ -126,7 +126,7 @@ def Workflow_fbl(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_fbl_labelfree_4dn.py
+++ b/aicssegmentation/structure_wrapper/seg_fbl_labelfree_4dn.py
@@ -82,7 +82,7 @@ def Workflow_fbl_labelfree_4dn(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = struct_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     bw_high_level = np.zeros_like(bw_low_level)
@@ -94,7 +94,7 @@ def Workflow_fbl_labelfree_4dn(
 
     # step 3: finer segmentation
     response2d = dot_2d_slice_by_slice_wrapper(struct_smooth, s2_param)
-    bw_finer = remove_small_objects(response2d, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d, min_size=minArea, connectivity=1)
 
     # merge finer level detection into high level coarse segmentation
     # to include outside dim parts
@@ -104,7 +104,7 @@ def Workflow_fbl_labelfree_4dn(
     # POST-PROCESSING
     # make sure the variable name of final segmentation is 'seg'
     ###################
-    seg = remove_small_objects(bw_high_level, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_high_level, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_gja1.py
+++ b/aicssegmentation/structure_wrapper/seg_gja1.py
@@ -95,12 +95,12 @@ def Workflow_gja1(
     # step 1: LOG 3d
     response = dot_3d(structure_img_smooth, log_sigma=dot_3d_sigma)
     bw = response > dot_3d_cutoff
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_h2b_interphase.py
+++ b/aicssegmentation/structure_wrapper/seg_h2b_interphase.py
@@ -86,7 +86,7 @@ def Workflow_h2b_interphase(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_lamp1.py
+++ b/aicssegmentation/structure_wrapper/seg_lamp1.py
@@ -132,7 +132,7 @@ def Workflow_lamp1(
 
     full_fill = np.logical_or(partial_fill, holes)
 
-    seg = remove_small_objects(full_fill, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(full_fill, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_lmnb1_mitotic.py
+++ b/aicssegmentation/structure_wrapper/seg_lmnb1_mitotic.py
@@ -95,7 +95,7 @@ def Workflow_lmnb1_mitotic(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = bw > 0

--- a/aicssegmentation/structure_wrapper/seg_myh10.py
+++ b/aicssegmentation/structure_wrapper/seg_myh10.py
@@ -92,7 +92,7 @@ def Workflow_myh10(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1.py
@@ -138,7 +138,7 @@ def Workflow_npm1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, out=seg)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1.py
@@ -100,7 +100,7 @@ def Workflow_npm1(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
@@ -138,7 +138,7 @@ def Workflow_npm1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, out=seg)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_npm1.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1.py
@@ -101,7 +101,7 @@ def Workflow_npm1(
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)

--- a/aicssegmentation/structure_wrapper/seg_npm1_SR.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1_SR.py
@@ -99,7 +99,7 @@ def Workflow_npm1_SR(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
@@ -131,7 +131,7 @@ def Workflow_npm1_SR(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, out=seg)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_npm1_SR.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1_SR.py
@@ -131,7 +131,7 @@ def Workflow_npm1_SR(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1, out=seg)
+    seg = remove_small_objects(bw_final, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_npm1_SR.py
+++ b/aicssegmentation/structure_wrapper/seg_npm1_SR.py
@@ -100,7 +100,7 @@ def Workflow_npm1_SR(
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     # step 2: high level thresholding
     local_cutoff = 0.333 * threshold_otsu(structure_img_smooth)

--- a/aicssegmentation/structure_wrapper/seg_npm_labelfree_4dn.py
+++ b/aicssegmentation/structure_wrapper/seg_npm_labelfree_4dn.py
@@ -84,7 +84,7 @@ def Workflow_npm_labelfree_4dn(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = struct_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     bw_high_level = np.zeros_like(bw_low_level)
@@ -96,7 +96,7 @@ def Workflow_npm_labelfree_4dn(
 
     # step 3: finer segmentation
     response2d = dot_2d_slice_by_slice_wrapper(struct_smooth, s2_param)
-    bw_finer = remove_small_objects(response2d, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d, min_size=minArea, connectivity=1)
 
     # merge finer level detection into high level coarse segmentation
     # to include outside dim parts
@@ -106,7 +106,7 @@ def Workflow_npm_labelfree_4dn(
     # POST-PROCESSING
     # make sure the variable name of final segmentation is 'seg'
     ###################
-    seg = remove_small_objects(bw_high_level, min_size=minArea, connectivity=1, in_place=True)
+    seg = remove_small_objects(bw_high_level, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_nup153.py
+++ b/aicssegmentation/structure_wrapper/seg_nup153.py
@@ -94,7 +94,7 @@ def Workflow_nup153(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_polr2a.py
+++ b/aicssegmentation/structure_wrapper/seg_polr2a.py
@@ -106,11 +106,11 @@ def Workflow_polr2a(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     from aicssegmentation.core.utils import remove_hot_pixel
 

--- a/aicssegmentation/structure_wrapper/seg_polr2a_blob.py
+++ b/aicssegmentation/structure_wrapper/seg_polr2a_blob.py
@@ -111,7 +111,7 @@ def Workflow_polr2a_blob(
     distance = distance_transform_edt(bw)
     im_watershed = watershed(
         -distance,
-        label(dilation(local_maxi, selem=ball(1))),
+        label(dilation(local_maxi, footprint=ball(1))),
         mask=bw,
         watershed_line=True,
     )

--- a/aicssegmentation/structure_wrapper/seg_polr2a_blob.py
+++ b/aicssegmentation/structure_wrapper/seg_polr2a_blob.py
@@ -97,7 +97,7 @@ def Workflow_polr2a_blob(
     # step 1: LOG 3d
     response = dot_3d(structure_img_smooth, log_sigma=dot_3d_sigma)
     bw = response > dot_3d_cutoff
-    bw = remove_small_objects(bw > 0, min_size=min_area, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=min_area, connectivity=1)
 
     out_img_list.append(bw.copy())
     out_name_list.append("interm_mask")
@@ -119,7 +119,7 @@ def Workflow_polr2a_blob(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(im_watershed, min_size=min_area, connectivity=1, in_place=False)
+    seg = remove_small_objects(im_watershed, min_size=min_area, connectivity=1)
 
     # remove hot pixels from segmentation output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_pxn.py
+++ b/aicssegmentation/structure_wrapper/seg_pxn.py
@@ -94,9 +94,9 @@ def Workflow_pxn(
 
     seg = np.zeros_like(bw)
     for zz in range(bw.shape[0]):
-        seg[zz, :, :] = remove_small_objects(bw[zz, :, :] > 0, min_size=minArea2D, connectivity=1, in_place=False)
+        seg[zz, :, :] = remove_small_objects(bw[zz, :, :] > 0, min_size=minArea2D, connectivity=1)
 
-    seg = remove_small_objects(seg > 0, min_size=minArea3D, connectivity=1, in_place=False)
+    seg = remove_small_objects(seg > 0, min_size=minArea3D, connectivity=1)
 
     # determine z-range
     bw_z = np.zeros(bw.shape[0], dtype=np.uint16)

--- a/aicssegmentation/structure_wrapper/seg_rab5a.py
+++ b/aicssegmentation/structure_wrapper/seg_rab5a.py
@@ -100,7 +100,7 @@ def Workflow_rab5a(
 
     # step 2: fill holes and remove small objects
     bw_filled = hole_filling(bw, hole_min, hole_max, True)
-    seg = remove_small_objects(bw_filled, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_filled, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_sec61b.py
+++ b/aicssegmentation/structure_wrapper/seg_sec61b.py
@@ -89,11 +89,11 @@ def Workflow_sec61b(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_sec61b_dual.py
+++ b/aicssegmentation/structure_wrapper/seg_sec61b_dual.py
@@ -89,11 +89,11 @@ def Workflow_sec61b_dual(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_slc25a17.py
+++ b/aicssegmentation/structure_wrapper/seg_slc25a17.py
@@ -97,7 +97,7 @@ def Workflow_slc25a17(
     response = dot_3d(structure_img_smooth, log_sigma=dot_3d_sigma)
     bw = response > dot_3d_cutoff
 
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw.copy())
     out_name_list.append("interm_mask")
@@ -119,7 +119,7 @@ def Workflow_slc25a17(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(im_watershed, min_size=minArea, connectivity=1)
 
     # HACK: Only for 2019 April Release #####
     if np.count_nonzero(seg > 0) < 50000:

--- a/aicssegmentation/structure_wrapper/seg_slc25a17.py
+++ b/aicssegmentation/structure_wrapper/seg_slc25a17.py
@@ -111,7 +111,7 @@ def Workflow_slc25a17(
     distance = distance_transform_edt(bw)
     im_watershed = watershed(
         -1 * distance,
-        label(dilation(local_maxi, selem=ball(1))),
+        label(dilation(local_maxi, footprint=ball(1))),
         mask=bw,
         watershed_line=True,
     )

--- a/aicssegmentation/structure_wrapper/seg_smc1a.py
+++ b/aicssegmentation/structure_wrapper/seg_smc1a.py
@@ -86,7 +86,7 @@ def Workflow_smc1a(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_son.py
+++ b/aicssegmentation/structure_wrapper/seg_son.py
@@ -96,11 +96,11 @@ def Workflow_son(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     seg = seg > 0
     seg = seg.astype(np.uint8)

--- a/aicssegmentation/structure_wrapper/seg_st6gal1.py
+++ b/aicssegmentation/structure_wrapper/seg_st6gal1.py
@@ -100,7 +100,7 @@ def Workflow_st6gal1(
 
     bw_low_level = structure_img_smooth > th_low_level
     bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1, in_place=True)
-    bw_low_level = dilation(bw_low_level, selem=ball(2))
+    bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     bw_high_level = np.zeros_like(bw_low_level)
     lab_low, num_obj = label(bw_low_level, return_num=True, connectivity=1)

--- a/aicssegmentation/structure_wrapper/seg_st6gal1.py
+++ b/aicssegmentation/structure_wrapper/seg_st6gal1.py
@@ -99,7 +99,7 @@ def Workflow_st6gal1(
     th_low_level = threshold_triangle(structure_img_smooth)
 
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=cell_wise_min_area, connectivity=1)
     bw_low_level = dilation(bw_low_level, footprint=ball(2))
 
     bw_high_level = np.zeros_like(bw_low_level)
@@ -123,7 +123,7 @@ def Workflow_st6gal1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_terf2.py
+++ b/aicssegmentation/structure_wrapper/seg_terf2.py
@@ -96,11 +96,11 @@ def Workflow_terf2(
     ###################
     # POST-PROCESSING
     ###################
-    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    bw = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
     for zz in range(bw.shape[0]):
-        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1, in_place=False)
+        bw[zz, :, :] = remove_small_objects(bw[zz, :, :], min_size=3, connectivity=1)
 
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     from aicssegmentation.core.utils import remove_hot_pixel
 

--- a/aicssegmentation/structure_wrapper/seg_tjp1.py
+++ b/aicssegmentation/structure_wrapper/seg_tjp1.py
@@ -96,7 +96,7 @@ def Workflow_tjp1(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_tomm20.py
+++ b/aicssegmentation/structure_wrapper/seg_tomm20.py
@@ -96,7 +96,7 @@ def Workflow_tomm20(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_tuba1b.py
+++ b/aicssegmentation/structure_wrapper/seg_tuba1b.py
@@ -90,7 +90,7 @@ def Workflow_tuba1b(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/structure_wrapper/seg_ubtf.py
+++ b/aicssegmentation/structure_wrapper/seg_ubtf.py
@@ -99,7 +99,7 @@ def Workflow_ubtf(
 
     th_low_level = (global_tri + global_median) / 2
     bw_low_level = structure_img_smooth > th_low_level
-    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, in_place=True)
+    bw_low_level = remove_small_objects(bw_low_level, min_size=low_level_min_size, connectivity=1, out=bw_low_level)
 
     # step 2: high level thresholding
     bw_high_level = np.zeros_like(bw_low_level)
@@ -114,7 +114,7 @@ def Workflow_ubtf(
 
     # step 3: finer segmentation
     response2d = dot_slice_by_slice(structure_img_smooth, log_sigma=dot_2d_sigma)
-    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1, in_place=True)
+    bw_finer = remove_small_objects(response2d > dot_2d_cutoff, min_size=minArea, connectivity=1)
 
     out_img_list.append(bw_finer.copy())
     out_name_list.append("bw_fine")
@@ -132,7 +132,7 @@ def Workflow_ubtf(
     ###################
     # POST-PROCESSING
     ###################
-    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1, in_place=False)
+    seg = remove_small_objects(bw_high_level > 0, min_size=minArea, connectivity=1)
 
     # output
     seg = seg > 0

--- a/aicssegmentation/tests/test_structures.py
+++ b/aicssegmentation/tests/test_structures.py
@@ -6,7 +6,7 @@ from aicsimageio import imread
 from pathlib import Path
 from aicsimageio.writers import OmeTiffWriter
 
-AGREE_THRESH = 0.999
+AGREE_THRESH = 0.997
 
 DEFAULT_MODULE_PATH = "aicssegmentation.structure_wrapper.seg_"
 

--- a/aicssegmentation/tests/workflow/test_all_workflows.py
+++ b/aicssegmentation/tests/workflow/test_all_workflows.py
@@ -14,7 +14,6 @@ class TestAllWorkflows:
 
     @pytest.mark.parametrize("workflow_name", SUPPORTED_STRUCTURE_NAMES)
     def test_execute_all_workflows(self, workflow_name, resources_dir):
-
         # Arrange
         img_path = resources_dir / "images" / "random_input.tiff"
         random_array = imread(img_path).reshape(*(128, 128, 128))

--- a/aicssegmentation/workflow/batch_workflow.py
+++ b/aicssegmentation/workflow/batch_workflow.py
@@ -151,7 +151,6 @@ class BatchWorkflow:
                 f"Using the Workflow: {self._workflow_definition.name}"
             )
         else:
-
             files_processed = self._processed_files - self._failed_files
             report = (
                 f"{files_processed}/{self._processed_files} files were successfully processed \n "

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,9 +69,9 @@ source_suffix = {
 master_doc = "index"
 
 # General information about the project.
-project = u"aicssegmentation"
-copyright = u"2020, Jianxu Chen"
-author = u"Jianxu Chen"
+project = "aicssegmentation"
+copyright = "2020, Jianxu Chen"
+author = "Jianxu Chen"
 
 # The version info for the project you"re documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -150,7 +150,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "aicssegmentation.tex", u"aicssegmentation Documentation", u"Jianxu Chen", "manual"),
+    (master_doc, "aicssegmentation.tex", "aicssegmentation Documentation", "Jianxu Chen", "manual"),
 ]
 
 
@@ -158,7 +158,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "aicssegmentation", u"aicssegmentation Documentation", [author], 1)]
+man_pages = [(master_doc, "aicssegmentation", "aicssegmentation Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -170,7 +170,7 @@ texinfo_documents = [
     (
         master_doc,
         "aicssegmentation",
-        u"aicssegmentation Documentation",
+        "aicssegmentation Documentation",
         author,
         "aicssegmentation",
         "One line description of project.",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "aicsimageio>=4.0.5",
     "scipy>=1.1.0",
     "numpy>=1.15.1",
-    "scikit-image<0.19.0",
+    "scikit-image",
     "pandas>=0.23.4",
     "itk",
     "itkwidgets",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "aicsimageio>=4.0.5",
     "scipy>=1.1.0",
     "numpy>=1.15.1",
-    "scikit-image>=0.18.0,=<0.19.2",
+    "scikit-image<0.19.0",
     "pandas>=0.23.4",
     "itk",
     "itkwidgets",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "aicsimageio>=4.0.5",
     "scipy>=1.1.0",
     "numpy>=1.15.1",
-    "scikit-image>=0.18.0,<0.19.0",
+    "scikit-image>=0.18.0,=<0.19.2",
     "pandas>=0.23.4",
     "itk",
     "itkwidgets",


### PR DESCRIPTION
This would allow us to support the latest version of napari, which requres skimage>=0.19.1.

According to the [release notes](https://scikit-image.org/docs/0.19.x/release_notes.html#id1,) only changes that affect us seem to be any functions that require the `selem` argument, which is now `footprint` instead.

Beyond this, I dont think there are other changes that would break aics-segmentation if we use the latest skimage.


